### PR TITLE
remove more duplicate and clean

### DIFF
--- a/sk_sk.aff
+++ b/sk_sk.aff
@@ -1,4 +1,4 @@
-# verzia: 2.05-alpha, 2021-02-07
+# verzia: 2.05-alpha, 2021-03-06
 SET UTF-8
 TRY aoeintsvrlkmdpuhjzácbyčžíšýúťéľôďgfňäóŕxĺwěřqůAOEINTSVRLKMDPUHJZÁCBYČŽÍŠÝÚŤÉĽÔĎGFŇÄÓŔXĹWĚŘQŮ
 
@@ -293,7 +293,7 @@ SFX U   ťa          tiach      ťa is:locative is:plural
 SFX U   a           iach       [^ďťňľi]a is:locative is:plural
 SFX U   a           ami        a is:instrumental is:plural
 
-SFX D Y 197
+SFX D Y 187
 SFX D   ec          ce         ec is:genitive
 SFX D   ď           de         ď is:genitive
 SFX D   eľ          le         seľ is:genitive
@@ -418,16 +418,6 @@ SFX D   ň           ne         [^bdhlrsšzv]eň is:accusative is:plural
 SFX D   ň           ne         [^e]ň is:accusative is:plural
 SFX D   ť           te         ť is:accusative is:plural
 SFX D   0           e          [^acďľňť] is:accusative is:plural
-SFX D   eľ          le         seľ is:accusative is:plural
-SFX D   ľ           le         [^s]eľ is:accusative is:plural
-SFX D   eň          ne         [bdhrsšzv]eň is:accusative is:plural
-SFX D   eň          ne         á[lš]eň is:accusative is:plural
-SFX D   eň          ne         i[aeu].eň is:accusative is:plural
-SFX D   ň           ne         [^á][lš]eň is:accusative is:plural
-SFX D   ň           ne         [^bdhlrsšzv]eň is:accusative is:plural
-SFX D   ň           ne         [^e]ň is:accusative is:plural
-SFX D   ť           te         ť is:accusative is:plural
-SFX D   0           e          [^acďľňť] is:accusative is:plural
 SFX D   ť           tiach      [^eúš]ť  is:locative is:plural
 SFX D   ť           tiach      [^i]eť is:locative is:plural
 SFX D   ť           ťach       ieť is:locative is:plural
@@ -531,7 +521,7 @@ SFX K   0           iach       [^áďťňľ] is:locative is:plural
 SFX K   á           ami        á is:instrumental is:plural
 SFX K   0           ami        [^á] is:instrumental is:plural
 
-SFX M Y 100
+SFX M Y 95
 SFX M   ďo          de         ďo is:genitive
 SFX M   ťo          te         ťo is:genitive
 SFX M   ňo          ne         ňo is:genitive
@@ -608,12 +598,7 @@ SFX M   o           á          [^áéíóŕúý].o is:accusative is:plural
 SFX M   um          á          ium is:accusative is:plural
 SFX M   um          á          [^i]um is:accusative is:plural
 SFX M   o           a          i[aeou]..o is:accusative is:plural
-SFX M   o           á          [^i][aeiouy]..o is:accusative is:plural
 SFX M   o           a          [áéíóŕúý]..o is:accusative is:plural
-SFX M   o           a          i[aeou].o is:accusative is:plural
-SFX M   o           a          [áéíóŕúý].o is:accusative is:plural
-SFX M   um          á          ium is:accusative is:plural
-SFX M   um          á          [^i]um is:accusative is:plural
 SFX M   o           ach        i[aeou]..o is:locative is:plural
 SFX M   o           ách        [^i][aeiouy]..o is:locative is:plural
 SFX M   o           ach        [áéíóŕúý]..o is:locative is:plural
@@ -675,7 +660,7 @@ SFX V   e           a          e is:accusative is:plural
 SFX V   e           ach        e is:locative is:plural
 SFX V   e           ami        e is:instrumental is:plural
 
-SFX A Y 35
+SFX A Y 31
 SFX A   0           ťa         . is:genitive
 SFX A   0           ťu         . is:dative
 SFX A   0           0          . is:accusative
@@ -699,10 +684,6 @@ SFX A   a           ence       [č]a is:accusative is:plural
 SFX A   0           nce        úbä is:accusative is:plural
 SFX A   a           ce         [^č]a is:accusative is:plural
 SFX A   0           tá         . is:accusative is:plural
-SFX A   a           ence       [č]a is:accusative is:plural
-SFX A   0           nce        úbä is:accusative is:plural
-SFX A   a           ce         [^č]a is:accusative is:plural
-SFX A   0           tá         . is:accusative is:plural
 SFX A   a           encoch     [č]a is:locative is:plural
 SFX A   0           ncoch      úbä is:locative is:plural
 SFX A   a           coch       [^č]a is:locative is:plural
@@ -712,7 +693,7 @@ SFX A   0           ncami      úbä is:instrumental is:plural
 SFX A   a           cami       [^č]a is:instrumental is:plural
 SFX A   0           tami       . is:instrumental is:plural
 
-SFX c Y 191 # vzor pre živ. pod.mená. ak N plurál je -ia
+SFX c Y 190 # vzor pre živ. pod.mená. ak N plurál je -ia
 SFX c   ec          če         ec is:vocative
 SFX c   0           ho         [éi] is:genitive
 SFX c   us          a          [^ú]..us is:genitive
@@ -810,7 +791,6 @@ SFX c   0           ovia       [^eo][cr] is:nominative is:plural
 SFX c   0           ovia       nc is:nominative is:plural
 SFX c   0           ovia       [^cčéior] is:nominative is:plural
 SFX c   0           ovia       [ey]n is:nominative is:plural
-SFX c   0           via        o is:nominative is:plural
 SFX c   or          rovia      [gk]or is:nominative is:plural
 SFX c   0           ovia       č[ei]k is:nominative is:plural
 SFX c   ok          kovia      ok is:nominative is:plural
@@ -905,7 +885,7 @@ SFX c   0           mi         [^eon][cr] is:instrumental is:plural
 SFX c   0           ami        nc is:instrumental is:plural
 SFX c   0           mi         [^céior] is:instrumental is:plural
 
-SFX C Y 113 # vzor pre živ. pod.mená. ak N plurál je -i okrem hosť
+SFX C Y 112 # vzor pre živ. pod.mená. ak N plurál je -i okrem hosť
 SFX C   ec          ca         ec is:genitive
 SFX C   on          na         zon is:genitive
 SFX C   o           a          o is:genitive
@@ -969,7 +949,6 @@ SFX C   er          ri         [^inp]er is:nominative is:plural
 SFX C   or          ri         bor is:nominative is:plural
 SFX C   0           i          [^b]or is:nominative is:plural
 SFX C   0           i          [^eo][cr] is:nominative is:plural
-SFX C   on          ni         zon is:nominative is:plural
 SFX C   ť           tí         ť is:genitive is:plural
 SFX C   ec          cov        ec is:genitive is:plural
 SFX C   on          nov        zon is:genitive is:plural
@@ -1648,7 +1627,7 @@ SFX Q   y           ami        [hkn]y is:instrumental is:plural
 SFX Q   asy         asmi       asy is:instrumental is:plural
 SFX Q   0           mi         ta is:instrumental is:plural
 
-SFX Y Y 323
+SFX Y Y 311
 SFX Y   e           ejšie      e po:adverb is:comparative
 SFX Y   e           ejšie      e po:adjective is:comparative is:neuter is:nominative is:plural
 SFX Y   e           ejšie      e po:adjective is:comparative is:feminine is:nominative is:plural
@@ -1675,8 +1654,6 @@ SFX Y   e           ejších     e po:adjective is:comparative is:feminine is:lo
 SFX Y   e           ejších     e po:adjective is:comparative is:neuter is:locative is:plural
 SFX Y   e           ejšom      e po:adjective is:comparative is:masculine is:locative
 SFX Y   e           ejšom      e po:adjective is:comparative is:neuter is:locative
-SFX Y   e           ejším      e po:adjective is:comparative is:masculine is:dative is:plural
-SFX Y   e           ejším      e po:adjective is:comparative is:neuter is:dative is:plural
 SFX Y   e           ejšou      e po:adjective is:comparative is:feminine is:instrumental
 SFX Y   e           ejšími     e po:adjective is:comparative is:masculine is:instrumental is:plural
 SFX Y   e           ejšími     e po:adjective is:comparative is:neuter is:instrumental is:plural
@@ -1712,7 +1689,6 @@ SFX Y   0           ého        m
 SFX Y   0           ej         m
 SFX Y   0           ých        m
 SFX Y   0           ému        m
-SFX Y   0           ej         m
 SFX Y   0           ým         m
 SFX Y   0           ú          m
 SFX Y   0           om         m
@@ -1782,10 +1758,8 @@ SFX Y   y           e          y is:neuter is:nominative
 SFX Y   y           e          y is:neuter is:accusative
 SFX Y   y           e          y is:masculine is:nominative
 SFX Y   y           e          y is:feminine is:nominative
-SFX Y   y           e          y is:neuter is:nominative
 SFX Y   y           e          y is:masculine is:accusative
 SFX Y   y           e          y is:feminine is:accusative
-SFX Y   y           e          y is:neuter is:accusative
 SFX Y   y           a          y is:feminine is:nominative
 SFX Y   y           i          y is:masculine is:nominative
 SFX Y   y           o          y po:adverb
@@ -1829,7 +1803,6 @@ SFX Y   y           ejších     [klntv]y is:comparative is:neuter is:accusative
 SFX Y   y           ejšiemu    [klntv]y is:comparative is:masculine is:dative
 SFX Y   y           ejšiemu    [klntv]y is:comparative is:neuter is:dative
 SFX Y   y           ejšej      [klntv]y is:comparative is:feminine is:dative
-SFX Y   y           ejšej      [klntv]y is:comparative is:feminine is:genitive
 SFX Y   y           ejším      [klntv]y is:comparative is:masculine is:dative is:plural
 SFX Y   y           ejším      [klntv]y is:comparative is:feminine is:dative is:plural
 SFX Y   y           ejším      [klntv]y is:comparative is:neuter is:dative is:plural
@@ -1929,7 +1902,6 @@ SFX Y   ý           ších       [dh]ý is:comparative is:neuter is:locative is
 SFX Y   ý           šiemu      [dh]ý is:comparative is:masculine is:dative
 SFX Y   ý           šiemu      [dh]ý is:comparative is:neuter is:dative
 SFX Y   ý           šej        [dh]ý is:comparative is:feminine is:dative
-SFX Y   ý           šej        [dh]ý is:comparative is:feminine is:locative
 SFX Y   ý           ším        [dh]ý is:comparative is:masculine is:dative is:plural
 SFX Y   ý           ším        [dh]ý is:comparative is:feminine is:dative is:plural
 SFX Y   ý           ším        [dh]ý is:comparative is:neuter is:dative is:plural
@@ -1941,11 +1913,6 @@ SFX Y   ý           ších       [dh]ý is:comparative is:neuter is:genitive is
 SFX Y   ý           ších       [dh]ý is:comparative is:masculine is:accusative is:plural
 SFX Y   ý           šom        [dh]ý is:comparative is:masculine is:locative
 SFX Y   ý           šom        [dh]ý is:comparative is:neuter is:locative
-SFX Y   ý           ším        [dh]ý is:comparative is:masculine is:dative is:plural
-SFX Y   ý           ším        [dh]ý is:comparative is:feminine is:dative is:plural
-SFX Y   ý           ším        [dh]ý is:comparative is:neuter is:dative is:plural
-SFX Y   ý           ším        [dh]ý is:comparative is:masculine is:instrumental
-SFX Y   ý           ším        [dh]ý is:comparative is:neuter is:instrumental
 SFX Y   ý           šou        [dh]ý is:comparative is:feminine is:instrumental
 SFX Y   ý           šími       [dh]ý is:comparative is:masculine is:instrumental is:plural
 SFX Y   ý           šími       [dh]ý is:comparative is:feminine is:instrumental is:plural

--- a/sk_sk.aff
+++ b/sk_sk.aff
@@ -1033,7 +1033,7 @@ SFX H   a           ov         a is:accusative is:plural
 SFX H   a           och        a is:locative is:plural
 SFX H   0           mi         a is:instrumental is:plural
 
-SFX B Y 215
+SFX B Y 214
 SFX B   0           a          [áéíóúý]rod is:genitive
 SFX B   0           u          [^áéíóúý]rod is:genitive
 SFX B   0           u          [^r]od is:genitive
@@ -1415,7 +1415,7 @@ SFX J   ôž          ožmi       ôž is:instrumental is:plural
 SFX J   0           mi         [e][^cľňr] is:instrumental is:plural
 SFX J   0           mi         [^ceľňršž] is:instrumental is:plural
 
-SFX L Y 79
+SFX L Y 77
 SFX L   ec          ca         ec is:genitive
 SFX L   o           a          o is:genitive
 SFX L   0           a          [tv]er is:genitive
@@ -1494,7 +1494,7 @@ SFX L   es          sami       es is:instrumental is:plural
 SFX L   0           mi         [^céior] is:instrumental is:plural
 SFX L   us          ami        us is:instrumental is:plural
 
-SFX O Y 102
+SFX O Y 97
 SFX O   ok          ka         ok is:genitive
 SFX O   el          lu         el is:genitive
 SFX O   ol          la         ol is:genitive

--- a/sk_sk.aff
+++ b/sk_sk.aff
@@ -4,7 +4,7 @@ TRY aoeintsvrlkmdpuhjzácbyčžíšýúťéľôďgfňäóŕxĺwěřqůAOEINTSVRL
 
 # replacenment table for
 # - multicharacter suggestions
-# - well-sorted suggestions 
+# - well-sorted suggestions
 
 REP 53
 REP a á
@@ -688,8 +688,8 @@ SFX A   0           tá         . is:nominative is:plural
 SFX A   a           eniec      [č]a is:genitive is:plural
 SFX A   0           niec       úbä is:genitive is:plural
 SFX A   a           iec        [^čň]a is:genitive is:plural
-SFX A	ňa          niec       [e]ňa is:genitive is:plural
-SFX A	ňa	    niat       [^i][^e]ňa is:genitive is:plural
+SFX A   ňa          niec       [e]ňa is:genitive is:plural
+SFX A   ňa          niat       [^i][^e]ňa is:genitive is:plural
 SFX A   0           t          [^ň]a is:genitive is:plural
 SFX A   a           encom      [č]a is:dative is:plural
 SFX A   0           ncom       úbä is:dative is:plural
@@ -719,7 +719,7 @@ SFX c   us          a          [^ú]..us is:genitive
 SFX c   0           a          úlius is:genitive
 SFX c   as          a          [^el]as is:genitive
 SFX c   0           a          [el]as is:genitive
-SFX c   es          a          [^hxz]es	is:genitive
+SFX c   es          a          [^hxz]es is:genitive
 SFX c   0           a          [hxz]es is:genitive
 SFX c   0           a          [^h]os is:genitive
 SFX c   os          a          hos is:genitive
@@ -758,7 +758,7 @@ SFX c   us          a          [^ú]..us is:accusative
 SFX c   0           a          úlius is:accusative
 SFX c   as          a          [^el]as is:accusative
 SFX c   0           a          [el]as is:accusative
-SFX c   es          a          [^hxz]es	is:accusative
+SFX c   es          a          [^hxz]es is:accusative
 SFX c   0           a          [hxz]es is:accusative
 SFX c   0           a          [^h]os is:accusative
 SFX c   os          a          hos is:accusative
@@ -1692,8 +1692,8 @@ SFX Y   i           ej         i is:feminine is:genitive
 SFX Y   i           ich        i is:masculine is:genitive is:plural
 SFX Y   i           ich        i is:feminine is:genitive is:plural
 SFX Y   i           ich        i is:neuter is:genitive is:plural
-SFX Y   i           emu        i is:masculine is:dative 
-SFX Y   i           emu        i is:neuter is:dative 
+SFX Y   i           emu        i is:masculine is:dative
+SFX Y   i           emu        i is:neuter is:dative
 SFX Y   i           im         i is:masculine is:dative is:plural
 SFX Y   i           im         i is:feminine is:dative is:plural
 SFX Y   i           im         i is:neuter is:dative is:plural
@@ -1878,7 +1878,7 @@ SFX Y   ý           ejšie      [kntv]ý is:comparative is:feminine is:nominati
 SFX Y   ý           ejšie      [kntv]ý is:comparative is:neuter is:nominative is:plural
 SFX Y   ý           ejšie      [kntv]ý is:comparative is:feminine is:accusative is:plural
 SFX Y   ý           ejšie      [kntv]ý is:comparative is:neuter is:accusative is:plural
-SFX Y   ý           ejšia      [kntv]ý is:comparative is:feminine is:nominative 
+SFX Y   ý           ejšia      [kntv]ý is:comparative is:feminine is:nominative
 SFX Y   ý           ejší       [kntv]ý is:comparative is:masculine is:nominative
 SFX Y   ý           ejšieho    [kntv]ý is:comparative is:masculine is:genitive
 SFX Y   ý           ejšieho    [kntv]ý is:comparative is:neuter is:genitive
@@ -1999,7 +1999,7 @@ SFX I   0           mi         í is:masculine is:instrumental is:plural
 SFX I   0           mi         í is:feminine is:instrumental is:plural
 SFX I   0           mi         í is:neuter is:instrumental is:plural
 SFX I   í           o          í po:adverb
-SFX I   í           ejší       í po:adjective is:comparative is:masculine is:nominative 
+SFX I   í           ejší       í po:adjective is:comparative is:masculine is:nominative
 SFX I   í           ejší       í po:adjective is:comparative is:masculine is:nominative is:plural
 SFX I   í           ejšia      í po:adjective is:comparative is:feminine is:nominative
 SFX I   í           ejšie      í po:adjective is:comparative is:feminine is:nominative is:plural
@@ -2031,8 +2031,8 @@ SFX P   0           m          í is:neuter is:dative is:plural
 SFX P   0           m          í is:masculine is:instrumental
 SFX P   0           m          í is:neuter is:instrumental
 SFX P   í           iu         í is:feminine is:accusative
-SFX P   í           om         í is:masculine is:locative 
-SFX P   í           om         í is:neuter is:locative 
+SFX P   í           om         í is:masculine is:locative
+SFX P   í           om         í is:neuter is:locative
 SFX P   í           ou         í is:feminine is:instrumental
 SFX P   0           mi         í is:masculine is:instrumental is:plural
 SFX P   0           mi         í is:feminine is:instrumental is:plural
@@ -2046,8 +2046,8 @@ SFX X   liať        ľajeme     kliať is:1st_person is:plural
 SFX X   liať        ľajete     kliať is:2nd_person is:plural
 SFX X   liať        ľajú       kliať is:3rd_person is:plural
 SFX X   liať        ľaj        kliať is:2nd_person is:imperative
-SFX X   liať        ľajme      kliať is:1st_person is:plural is:imperative 
-SFX X   liať        ľajte      kliať is:2nd_person is:plural is:imperative 
+SFX X   liať        ľajme      kliať is:1st_person is:plural is:imperative
+SFX X   liať        ľajte      kliať is:2nd_person is:plural is:imperative
 SFX X   liať        ľajúc      kliať is:participle
 SFX X   iať         ejem       [^k]liať is:1st_person
 SFX X   iať         eješ       [^k]liať is:2nd_person
@@ -3167,4 +3167,3 @@ SFX č   0           násobných  . po:adjective is:accusative is:masculine is:p
 SFX č   0           násobné    . po:adjective is:accusative is:feminine is:plural
 SFX č   0           násobné    . po:adjective is:accusative is:neuter is:plural
 SFX č   0           násobnými  . po:adjective is:instrumental is:plural
-


### PR DESCRIPTION
Este mierne upravy:
1) v predchadzajucom commit-e (https://github.com/sk-spell/hunspell-sk/pull/35) pri mazani duplicitnych riadkov som zabudol upravit, resp. znizit aj number of rules v `sk_sk.aff` subore
2) mazanie whitespace a zamena TABs na spaces (zamedzenie zbytocnemu "bolehlavu" pri parsovani suboru)
3) slovo "Žrnové" duplicitne
4) doplnujuce mazanie duplicitnych riadkov (uz vratane spravneho number of rules)

Do buducna, pri hladani duplicitnych riadkov, odporucam elegantne a jednoduche [riesenie](https://unix.stackexchange.com/questions/30173/how-to-remove-duplicate-lines-inside-a-text-file).
`$ gawk '/^\s*?$/||!seen[$0]++' sk_sk.aff > sk_sk.aff.new`
Netreba sa zbytocne "trapit" s `sort | uniq` a prikaz `gawk` krasne funguje aj s `sk_sk.dic` suborom.