### PR TITLE
Úprava pre vzor ulica

### DIFF
--- a/sk_SK.aff
+++ b/sk_SK.aff
@@ -271,13 +271,12 @@ SFX Z   a           ami        a is:instrumental is:plural
 SFX Z   a           ách        ina is:locative is:plural
 SFX Z   a           ach        ína is:locative is:plural
 
-SFX U Y 48
+SFX U Y 49
 SFX U   a           e          [^ďťňľ]a is:genitive
 SFX U   ďa          de         ďa is:genitive
 SFX U   ľa          le         ľa is:genitive
 SFX U   ňa          ne         ňa is:genitive
 SFX U   ťa          te         ťa is:genitive
-SFX U   a           e          ia is:genitive
 SFX U   a           i          [^ďťňľ]a is:dative
 SFX U   ďa          di         ďa is:dative
 SFX U   ľa          li         ľa is:dative
@@ -305,18 +304,20 @@ SFX U   yňa         ýň         yňa is:genitive is:plural
 SFX U   ďa          dí         ďa is:genitive is:plural
 SFX U   a           ám         ia is:dative is:plural
 SFX U   ďa          diam       ďa is:dative is:plural
-SFX U   ňa          niam       ňa is:dative is:plural
+SFX U   ňa          ňam        [áéíóúýô]ňa is:dative is:plural
+SFX U   ňa          niam       [^áéíóúýô]ňa is:dative is:plural
 SFX U   ťa          tiam       ťa is:dative is:plural
 SFX U   a           iam        [^ďťňľi]a is:dative is:plural
-SFX U   ľa          ľam        [áéíóúý]ľa is:dative is:plural
-SFX U   ľa          liam       [^áéíóúý]ľa is:dative is:plural
+SFX U   ľa          ľam        [áéíóúýô]ľa is:dative is:plural
+SFX U   ľa          liam       [^áéíóúýô]ľa is:dative is:plural
 SFX U   ďa          de         ďa is:accusative is:plural
 SFX U   ľa          le         ľa is:accusative is:plural
 SFX U   a           ách        ia is:locative is:plural
 SFX U   ďa          diach      ďa is:locative is:plural
-SFX U   ľa          ľach       [áéíóúý]ľa is:locative is:plural
-SFX U   ľa          liach      [^áéíóúý]ľa is:locative is:plural
-SFX U   ňa          niach      ňa is:locative is:plural
+SFX U   ľa          ľach       [áéíóúýô]ľa is:locative is:plural
+SFX U   ľa          liach      [^áéíóúýô]ľa is:locative is:plural
+SFX U   ňa          ňach       [áéíóúýô]ňa is:locative is:plural
+SFX U   ňa          niach      [^áéíóúýô]ňa is:locative is:plural
 SFX U   ťa          tiach      ťa is:locative is:plural
 SFX U   a           iach       [^ďťňľi]a is:locative is:plural
 SFX U   a           ami        a is:instrumental is:plural


### PR DESCRIPTION
Odstránil som nadbytočný riadok pre genitív. Opravil som rytmické krátenie, aby sa aplikovalo aj pri ô (napr. slovo vôľa. V zozname slov už bolo manuálne zadané slovo "vôľam", ale zároveň bolo nesprávne slovo "vôliam" považované pred touto opravou za správne. Novovzniknuté duplikáty som zatiaľ neodstraňoval.) Taktiež som rozšíril rytmické krátenie pre slová končiace sa na "-ňa". (Doteraz bolo len pre slová končiace sa na "-ľa".)

Ak si dám vygenerovať vyskloňované tvary všetkých slov vzoru ulica (t.j. označených `/U`) pomocou scriptu `wordforms` z Hunspellu pre pôvodný a zmenený `sk-SK.aff` a porovnám výsledky pomocou `diff`, toto je výsledok:
```
2976a2977,2978
> blahovôľach
> blahovôľam
2980,2981d2981
< blahovôliach
< blahovôliam
16516a16517,16518
> ľubovôľach
> ľubovôľam
16520,16521d16521
< ľubovôliach
< ľubovôliam
18757a18758,18759
> nevôľach
> nevôľam
18761,18762d18762
< nevôliach
< nevôliam
24492a24493,24494
> ríňach
> ríňam
24496,24497d24497
< ríniach
< ríniam
24870a24871,24872
> samovôľach
> samovôľam
24874,24875d24875
< samovôliach
< samovôliam
25627a25628,25629
> skláňach
> skláňam
25631,25632d25632
< sklániach
< sklániam
26731a26732,26733
> strapáňach
> strapáňam
26739d26740
< strapániach
26741d26741
< strapániam
27424a27425,27426
> svojvôľach
> svojvôľam
27428,27429d27429
< svojvôliach
< svojvôliam
27624a27625,27626
> Táňach
> Táňam
27637,27638d27638
< Tániach
< Tániam
28164a28165,28166
> tôňach
> tôňam
28168,28169d28169
< tôniach
< tôniam
29993a29994,29995
> vôľach
> vôľam
29997,29998d29998
< vôliach
< vôliam
30001a30002,30003
> vôňach
> vôňam
30005,30006d30006
< vôniach
< vôniam
30736a30737,30738
> zlovôľach
> zlovôľam
30740,30741d30741
< zlovôliach
< zlovôliam
```

Z nejakého neznámeho dôvodu ukazuje Github neviditeľné zmeny aj na miestach, ktoré som neupravoval. Pomocou `wordforms` som si overil, že to tieto zmeny nemajú žiadne účinky.