### PR TITLE
Opravy pre vzor stroj a zmeny vzorov v sk_SK.dic

### DIFF
--- a/sk_SK.aff
+++ b/sk_SK.aff
@@ -1284,8 +1284,8 @@ SFX J   0           a          [^o]r is:genitive
 SFX J   ôš          oša        ôš is:genitive
 SFX J   eť          ťa         eť is:genitive
 SFX J   ôž          oža        ôž is:genitive
-SFX J   0           a          [e][^cľňr] is:genitive
-SFX J   0           a          [^ceľňršž] is:genitive
+SFX J   0           a          [e][^clľňr] is:genitive
+SFX J   0           a          [^e][^ceľňršž] is:genitive
 SFX J   iec         cu         iec is:dative
 SFX J   ec          cu         [^i]ec is:dative
 SFX J   0           u          [^e]c is:dative
@@ -1301,8 +1301,8 @@ SFX J   0           u          [^o]r is:dative
 SFX J   ôš          ošu        ôš is:dative
 SFX J   eť          ťu         eť is:dative
 SFX J   ôž          ožu        ôž is:dative
-SFX J   0           u          [e][^cľňr] is:dative
-SFX J   0           u          [^ceľňršž] is:dative
+SFX J   0           u          [e][^clľňr] is:dative
+SFX J   0           u          [^e][^ceľňršž] is:dative
 SFX J   iec         ci         iec is:locative
 SFX J   ec          ci         [^i]ec is:locative
 SFX J   0           i          [^e]c is:locative
@@ -1319,8 +1319,8 @@ SFX J   0           i          [^o]r is:locative
 SFX J   ôš          oši        ôš is:locative
 SFX J   eť          ti         eť is:locative
 SFX J   ôž          oži        ôž is:locative
-SFX J   0           i          [e][^cľňr] is:locative
-SFX J   0           i          [^ceľňršž] is:locative
+SFX J   0           i          [e][^clľňr] is:locative
+SFX J   0           i          [^e][^ceľňršž] is:locative
 SFX J   ec          com        [^i]ec is:instrumental
 SFX J   0           om         [^e]c is:instrumental
 SFX J   el          lom        el is:instrumental
@@ -1335,8 +1335,8 @@ SFX J   0           om         [^o]r is:instrumental
 SFX J   ôš          ošom       ôš is:instrumental
 SFX J   eť          ťom        eť is:instrumental
 SFX J   ôž          ožom       ôž is:instrumental
-SFX J   0           om         [e][^cľňr] is:instrumental
-SFX J   0           om         [^ceľňršž] is:instrumental
+SFX J   0           om         [e][^clľňr] is:instrumental
+SFX J   0           om         [^e][^ceľňršž] is:instrumental
 SFX J   iec         ce         iec is:nominative is:plural
 SFX J   ec          ce         [^i]ec is:nominative is:plural
 SFX J   0           e          [^e]c is:nominative is:plural
@@ -1353,8 +1353,8 @@ SFX J   0           e          [^o]r is:nominative is:plural
 SFX J   ôš          oše        ôš is:nominative is:plural
 SFX J   eť          te         eť is:nominative is:plural
 SFX J   ôž          ože        ôž is:nominative is:plural
-SFX J   0           e          [e][^cľňr] is:nominative is:plural
-SFX J   0           e          [^ceľňršž] is:nominative is:plural
+SFX J   0           e          [e][^clľňr] is:nominative is:plural
+SFX J   0           e          [^e][^ceľňršž] is:nominative is:plural
 SFX J   iec         cov        iec is:genitive is:plural
 SFX J   ec          cov        [^i]ec is:genitive is:plural
 SFX J   0           ov         [^e]c is:genitive is:plural
@@ -1370,8 +1370,8 @@ SFX J   0           ov         [^o]r is:genitive is:plural
 SFX J   ôš          ošov       ôš is:genitive is:plural
 SFX J   eť          ťov        eť is:genitive is:plural
 SFX J   ôž          ožov       ôž is:genitive is:plural
-SFX J   0           ov         [e][^cľňr] is:genitive is:plural
-SFX J   0           ov         [^ceľňršž] is:genitive is:plural
+SFX J   0           ov         [e][^clľňr] is:genitive is:plural
+SFX J   0           ov         [^e][^ceľňršž] is:genitive is:plural
 SFX J   iec         com        iec is:dative is:plural
 SFX J   ec          com        [^i]ec is:dative is:plural
 SFX J   0           om         [^e]c is:dative is:plural
@@ -1387,8 +1387,8 @@ SFX J   0           om         [^o]r is:dative is:plural
 SFX J   ôš          ošom       ôš is:dative is:plural
 SFX J   eť          ťom        eť is:dative is:plural
 SFX J   ôž          ožom       ôž is:dative is:plural
-SFX J   0           om         [e][^cľňr] is:dative is:plural
-SFX J   0           om         [^ceľňršž] is:dative is:plural
+SFX J   0           om         [e][^clľňr] is:dative is:plural
+SFX J   0           om         [^e][^ceľňršž] is:dative is:plural
 SFX J   iec         ce         iec is:accusative is:plural
 SFX J   ec          ce         [^i]ec is:accusative is:plural
 SFX J   0           e          [^e]c is:accusative is:plural
@@ -1405,8 +1405,8 @@ SFX J   0           e          [^o]r is:accusative is:plural
 SFX J   ôš          oše        ôš is:accusative is:plural
 SFX J   eť          te         eť is:accusative is:plural
 SFX J   ôž          ože        ôž is:accusative is:plural
-SFX J   0           e          [e][^cľňr] is:accusative is:plural
-SFX J   0           e          [^ceľňršž] is:accusative is:plural
+SFX J   0           e          [e][^clľňr] is:accusative is:plural
+SFX J   0           e          [^e][^ceľňršž] is:accusative is:plural
 SFX J   iec         coch       iec is:locative is:plural
 SFX J   ec          coch       [^i]ec is:locative is:plural
 SFX J   0           och        [^e]c is:locative is:plural
@@ -1423,8 +1423,8 @@ SFX J   0           och        [^o]r is:locative is:plural
 SFX J   ôš          ošoch      ôš is:locative is:plural
 SFX J   eť          ťoch       eť is:locative is:plural
 SFX J   ôž          ožoch      ôž is:locative is:plural
-SFX J   0           och        [e][^cľňr] is:locative is:plural
-SFX J   0           och        [^ceľňršž] is:locative is:plural
+SFX J   0           och        [e][^clľňr] is:locative is:plural
+SFX J   0           och        [^e][^ceľňršž] is:locative is:plural
 SFX J   iec         cami       iec is:instrumental is:plural
 SFX J   ec          cami       [^i]ec is:instrumental is:plural
 SFX J   0           mi         [^e]c is:instrumental is:plural
@@ -1440,8 +1440,8 @@ SFX J   0           ami        [^o]r is:instrumental is:plural
 SFX J   ôš          ošmi       ôš is:instrumental is:plural
 SFX J   eť          ťami       eť is:instrumental is:plural
 SFX J   ôž          ožmi       ôž is:instrumental is:plural
-SFX J   0           mi         [e][^cľňr] is:instrumental is:plural
-SFX J   0           mi         [^ceľňršž] is:instrumental is:plural
+SFX J   0           mi         [e][^clľňr] is:instrumental is:plural
+SFX J   0           mi         [^e][^ceľňršž] is:instrumental is:plural
 SFX J   0           a          [aádeéiílĺnoruúyý][šž] is:genitive
 SFX J   0           ovi        ĺž is:dative
 SFX J   0           ovi        ĺž is:locative

--- a/sk_SK.dic
+++ b/sk_SK.dic
@@ -13865,7 +13865,14 @@ daniarov/Y po:adjective
 Danica/U po:noun is:feminine
 danie/VN po:noun is:neuter
 Daniel/c po:noun is:masculine
-daniel/J po:noun is:masculine
+daniel	 po:noun is:masculine
+daniela
+danielovi
+danielom
+daniele
+danielov
+danieloch
+danielmi
 Daniela/zZ po:noun is:feminine
 Danielách
 Danielám
@@ -45812,7 +45819,7 @@ kovonosné
 kovonosných
 kovonosným
 kovoobrábací/I po:adjective
-kovopriemysel/J po:noun is:masculine
+kovopriemysel/O po:noun is:masculine
 kovopriemyselného
 kovopriemysly
 kovorobotnícky/YN po:adjective
@@ -102667,7 +102674,14 @@ púčky
 púčok/B po:noun is:masculine
 pud/B po:noun is:masculine
 pudami
-pudel/J po:noun is:masculine
+pudel	 po:noun is:masculine
+pudla
+pudlovi
+pudlom
+pudle
+pudlov
+pudloch
+pudlami
 pudelpointer
 púder/J po:noun is:masculine
 pudilár/B po:noun is:masculine
@@ -113574,7 +113588,14 @@ skalopevne
 skalopevnosť/K po:noun is:feminine
 skalopevný/YN po:adjective
 skalp/B po:noun is:masculine
-skalpel/J po:noun is:masculine
+skalpel	 po:noun is:masculine
+skalpela
+skalpelu
+skalpeli
+skalpelom
+skalpelov
+skalpeloch
+skalpelmi
 skalpely
 skalpovací/I po:adjective
 skalpovanie/VN po:noun is:neuter
@@ -114113,7 +114134,7 @@ skormútila
 skormútiť
 skoro/N
 skorobarokový/YN po:adjective
-skorocel/J po:noun is:masculine
+skorocel/b po:noun is:masculine
 skorocelový/YN po:adjective
 skorocely
 skorodit
@@ -125224,7 +125245,14 @@ SZTK	 po:acronym
 špalta/zZ po:noun is:feminine
 špan
 Španiel/C po:noun is:masculine
-španiel/J po:noun is:masculine
+španiel	 po:noun is:masculine
+španiela
+španielovi
+španielom
+španiele
+španielov
+španieloch
+španielmi
 španielčin
 španielčina/z po:noun is:feminine
 španielčinách


### PR DESCRIPTION
Opravil som .aff súbor, aby nevytváral nesprávne tvary pri flagu J tam, kde sa vynecháva "e" v koncovke. Napríklad pre slovo "bicykel" bol (popri správnom tvare "bicykla") chybne považovaný za správny tvar "bicykela". Niekoľkým slovám som menil vzor. Vyskytli sa 4 slová, ktorým žiadel flag negeneroval správne tvary, preto som ho odstránil a manuálne som pridal správne vyskloňované tvary. Sú to tieto:

- *španiel* - hodil by sa k nemu flag L (keďže ide o zvieracie podstatné meno mužského rodu), no ten generuje nesprávny plurál "španiely" miesto "španiele"
- *daniel* - to isté
- *pudel* - flag L nepodporuje vynechávanie "e" pri skloňovaní
- *skalpel* - žiaden flag negeneruje nominatív pl. "-y", genitív sg. "-u", lokál sg. "-i"

Pre flag "b" chybne chýba generovanie tvaru pre lokál singuláru. Túto chybu som zatiaľ neopravoval, takže zatiaľ slovu "skorocel", ktorému som zmenil flag na "b", chýba tvar "skorocele".

Tu je rozdiel (generovaný pomocou `diff`) vo vyskloňovaných tvaroch (generovaných pomocou `wordforms`) všetkých slov s flagom J a so zmenenými flagmi. (Kvôli tomu, ako som tieto tvary generoval, sa tu nenachádzajú ručne pridané tvary štyroch slov, ktoré som spomínal).
```
149,156d148
< artikela
< artikele
< artikeli
< artikelmi
< artikeloch
< artikelom
< artikelov
< artikelu
185,192d176
< axela
< axele
< axeli
< axelmi
< axeloch
< axelom
< axelov
< axelu
342,349d325
< bicykela
< bicykele
< bicykeli
< bicykelmi
< bicykeloch
< bicykelom
< bicykelov
< bicykelu
1335,1338d1310
< daniel
< daniela
< daniele
< danieli
1347,1359d1318
< danielmi
< danieloch
< danielom
< danielov
< danielu
< danila
< danilami
< danile
< danili
< daniloch
< danilom
< danilov
< danilu
1395,1402d1353
< debakela
< debakele
< debakeli
< debakelmi
< debakeloch
< debakelom
< debakelov
< debakelu
2059,2066d2009
< fascikela
< fascikele
< fascikeli
< fascikelmi
< fascikeloch
< fascikelom
< fascikelov
< fascikelu
3188,3195d3130
< kábela
< kábele
< kábeli
< kábelmi
< kábeloch
< kábelom
< kábelov
< kábelu
4075,4083d4009
< kovopriemysela
< kovopriemysele
< kovopriemyseli
< kovopriemyselmi
< kovopriemyseloch
< kovopriemyselom
< kovopriemyselov
< kovopriemyselu
< kovopriemysla
4086d4011
< kovopriemysli
4090a4016
> kovopriemysly
5728,5735d5653
< monokela
< monokele
< monokeli
< monokelmi
< monokeloch
< monokelom
< monokelov
< monokelu
5763,5770d5680
< motocykela
< motocykele
< motocykeli
< motocykelmi
< motocykeloch
< motocykelom
< motocykelov
< motocykelu
7483,7490d7392
< pajzela
< pajzele
< pajzeli
< pajzelmi
< pajzeloch
< pajzelom
< pajzelov
< pajzelu
9608,9616d9509
< pudel
< pudela
< pudele
< pudeli
< pudelmi
< pudeloch
< pudelom
< pudelov
< pudelu
9626,9633d9518
< pudla
< pudlami
< pudle
< pudli
< pudloch
< pudlom
< pudlov
< pudlu
10867,10874d10751
< singela
< singele
< singeli
< singelmi
< singeloch
< singelom
< singelov
< singelu
10926,10942d10802
< skalpel
< skalpela
< skalpele
< skalpeli
< skalpelmi
< skalpeloch
< skalpelom
< skalpelov
< skalpelu
< skalpla
< skalplami
< skalple
< skalpli
< skalploch
< skalplom
< skalplov
< skalplu
11005,11007d10864
< skorocela
< skorocele
< skoroceli
11013,11020c10870
< skorocla
< skoroclami
< skorocle
< skorocli
< skorocloch
< skoroclom
< skoroclov
< skoroclu
---
> skorocely
11429,11436d11278
< sokela
< sokele
< sokeli
< sokelmi
< sokeloch
< sokelom
< sokelov
< sokelu
11488,11504d11329
< španiel
< španiela
< španiele
< španieli
< španielmi
< španieloch
< španielom
< španielov
< španielu
< španila
< španilami
< španile
< španili
< španiloch
< španilom
< španilov
< španilu
12692,12699d12516
< triangela
< triangele
< triangeli
< triangelmi
< triangeloch
< triangelom
< triangelov
< triangelu
13355,13362d13171
< vehikela
< vehikele
< vehikeli
< vehikelmi
< vehikeloch
< vehikelom
< vehikelov
< vehikelu
```