### PR TITLE
Opravy flagu "b" v .aff

### DIFF
--- a/doc/AUTHORS
+++ b/doc/AUTHORS
@@ -22,3 +22,4 @@ Contributors/Prispievatelia:
   - Július Pastierik <pastierik (zavináč) inet (bodka) sk>
   - Jozef Riha <jose1711 (zavináč) gmail (bodka) com>
   - Vladimír Benko <vladimir.benko (zavináč) juls (bodka) savba (bodka) sk>
+  - samo-sk <4chsikp9 (zavináč) samo1 (bodka) anonaddy (bodka) com>

--- a/sk_SK.aff
+++ b/sk_SK.aff
@@ -3576,14 +3576,17 @@ SFX R   ýzť         yz         ýzť is:2nd_person is:imperative
 SFX R   ýzť         yzme       ýzť is:1st_person is:plural is:imperative
 SFX R   ýzť         yzte       ýzť is:2nd_person is:plural is:imperative
 
-SFX b Y 8  # v testovaní: pred podst. mena vzoru dub s -u v G a -e L
+SFX b Y 11  # v testovaní: pred podst. mena vzoru dub s -u v G a -e L
 SFX b   0           u          [klr] is:genitive
-SFX b   0           om         [klr] is:dative
+SFX b   0           u          [klr] is:dative
+SFX b   0           0          [klr] is:accusative
+SFX b   0           e          [klr] is:locative
+SFX b   0           om         [klr] is:instrumental
 SFX b   0           y          [klr] is:nominative is:plural
 SFX b   0           ov         [klr] is:genitive is:plural
+SFX b   0           om         [klr] is:dative is:plural
 SFX b   0           y          [klr] is:accusative is:plural
 SFX b   0           och        [klr] is:locative is:plural
-SFX b   0           om         [klr] is:instrumental is:plural
 SFX b   0           mi         [klr] is:instrumental is:plural
 
 SFX n Y 15  # v testovaní: pre číslovky


### PR DESCRIPTION
Pre flag `b` som pridal chýbajúcu koncovku "-e" (lokál). Tiež som opravil označenia koncovky "-om" (nie je v datíve sg. a inštrumentáli pl., ale v inštrumentáli sg. a datíve pl.).

Keďže koncovka "-om" je v tomto flagu dvakrát (raz označená ako inštrumentál, druhý raz ako datív), tak som podobne pridal koncovku "-u" označenú ako datív (už predtým tam bola táto koncovka raz, označená ako genitív). Tiež som pridal riadok, že akuzatív je voči základnému tvaru nezmenený. (Viacero iných flagov už malo takto definovaný "nezmenený" akuzatív.)

Tu je diff vygenerovaných tvarov:
```
1a2
> bále
8a10
> charaktere
15a18
> globále
22a26
> komunále
29a34
> kondyle
36a42
> kultivátore
43a50
> nátere
50a58
> Nepále
57a66
> normále
64a74
> odere
71a82
> otere
79a91,92
> ovale
> ovále
92a106
> paškále
99a114
> paušále
106a122
> polotvare
113a130
> potere
120a138
> protiúdere
127a146
> rádiožurnále
134a154
> šále
141a162
> škandále
148a170
> skorocele
155a178
> stere
162a186
> údere
169a194
> výtere
176a202
> zádere
183a210
> žurnále
```

Tiež som sa pridal do súboru `doc/AUTHORS`.